### PR TITLE
filterExtendedのmaskがうまく動作していないため修正

### DIFF
--- a/src/ESP32SJA1000.cpp
+++ b/src/ESP32SJA1000.cpp
@@ -327,7 +327,7 @@ int ESP32SJA1000Class::filter(int id, int mask)
 int ESP32SJA1000Class::filterExtended(long id, long mask)
 {
   id &= 0x1FFFFFFF;
-  mask &= ~(mask & 0x1FFFFFFF);
+  mask = ~(mask & 0x1FFFFFFF);
 
   modifyRegister(REG_MOD, 0x17, 0x01); // reset
 


### PR DESCRIPTION
fork元にプルリクを発行しようと思いましたが、すでに発行されていてしかもガンスルーされてたのでこちらだけで。

元の状態だとこんな感じ
```
mask &= ~(mask & 0x1FFFFFFF);
mask & ~(mask & FFFF)  // 思考簡略化のためFFFFに短縮、代入処理を&に展開
mask & (~mask + 0000)  // 反転をカッコ内に代入　ド・モルガンの法則により&から+に
mask & ~mask + mask & 0000  // 掛け算はカッコ内の各々に行うことができる
0000  // A & ~Aは0、x & 0も0
```
&=から&を取るだけで大丈夫です。
一応maskについては以下のような仕組みらしいっす…
![Screenshot from 2023-11-24 09-43-52](https://github.com/arav-jp/arduino-CAN/assets/11350811/80954f1b-a202-441d-a02b-5f31c965c42a)
https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf
↑これの556ページ